### PR TITLE
unity-chan用のToonシェーダーの実装

### DIFF
--- a/Assets/Scenes/TryToonShader.unity
+++ b/Assets/Scenes/TryToonShader.unity
@@ -441,7 +441,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1608975916}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -1.009}
+  m_LocalPosition: {x: 0, y: 1, z: -1.191}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scenes/TryToonShader.unity
+++ b/Assets/Scenes/TryToonShader.unity
@@ -234,7 +234,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.165
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.x
@@ -242,7 +242,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.z
@@ -250,7 +250,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_RootOrder
@@ -262,7 +262,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -358,7 +358,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 941110970}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.388, y: 0.34770405, z: -2.5447688}
+  m_LocalPosition: {x: 1.388, y: 0.34770405, z: 1.69}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -441,7 +441,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1608975916}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 1, z: -1.009}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/body.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/body.mat
@@ -2,78 +2,54 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 3
+  serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: body
   m_Shader: {fileID: 4800000, guid: 96d05de60c5f7474491f9f94568cf623, type: 3}
-  m_ShaderKeywords: []
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-      data:
-        first:
-          name: _MainTex
-        second:
-          m_Texture: {fileID: 2800000, guid: f9c6074c5a78e71448f9efd3013cadda, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _FalloffSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: cc8f70f2ec571e9478efa98c041cde7b, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _RimLightSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _SpecularReflectionSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: 7ae1142e9b3a72048960dd9561e0e0d9, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _EnvMapSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: 763c5d30206d1d54a9b49b3309e37fe1, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _NormalMapSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: 3a3c0acc807e9264ca0b32602a928a9a, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
+    - _EnvMapSampler:
+        m_Texture: {fileID: 2800000, guid: 763c5d30206d1d54a9b49b3309e37fe1, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FalloffSampler:
+        m_Texture: {fileID: 2800000, guid: cc8f70f2ec571e9478efa98c041cde7b, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: f9c6074c5a78e71448f9efd3013cadda, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapSampler:
+        m_Texture: {fileID: 2800000, guid: 3a3c0acc807e9264ca0b32602a928a9a, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _RimLightSampler:
+        m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularReflectionSampler:
+        m_Texture: {fileID: 2800000, guid: 7ae1142e9b3a72048960dd9561e0e0d9, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
-      data:
-        first:
-          name: _FalloffPower
-        second: .300000012
-      data:
-        first:
-          name: _EdgeThickness
-        second: .5
-      data:
-        first:
-          name: _SpecularPower
-        second: 20
+    - _EdgeThickness: 0.5
+    - _FalloffPower: 0.3
+    - _OutlineWidth: 0.01
+    - _SpecularPower: 20
     m_Colors:
-      data:
-        first:
-          name: _Color
-        second: {r: 1, g: 1, b: 1, a: 1}
-      data:
-        first:
-          name: _ShadowColor
-        second: {r: .800000012, g: .800000012, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _OutLineColor: {r: 1, g: 0.09249612, b: 0, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/body.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/body.mat
@@ -46,10 +46,12 @@ Material:
     m_Floats:
     - _EdgeThickness: 0.5
     - _FalloffPower: 0.3
-    - _OutlineWidth: 0.01
+    - _OutlineWidth: 0.02
     - _SpecularPower: 20
     m_Colors:
+    - _BlightColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DarkColor: {r: 0.5754717, g: 0.5754717, b: 0.5754717, a: 1}
     - _OutLineColor: {r: 1, g: 0.09249612, b: 0, a: 1}
     - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
     - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/face.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/face.mat
@@ -2,53 +2,43 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 3
+  serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: face
   m_Shader: {fileID: 4800000, guid: b35a2abbdd5b15d4ca40103088758eac, type: 3}
-  m_ShaderKeywords: []
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-      data:
-        first:
-          name: _MainTex
-        second:
-          m_Texture: {fileID: 2800000, guid: 3cf2e516b5353d5499c41818747b4155, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _FalloffSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a1d5b2277eb3f6245900378e6fa97575, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _RimLightSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
+    - _FalloffSampler:
+        m_Texture: {fileID: 2800000, guid: a1d5b2277eb3f6245900378e6fa97575, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 3cf2e516b5353d5499c41818747b4155, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _RimLightSampler:
+        m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
-      data:
-        first:
-          name: _FalloffPower
-        second: 1
-      data:
-        first:
-          name: _EdgeThickness
-        second: .5
+    - _EdgeThickness: 0.5
+    - _FalloffPower: 1
+    - _OutlineWidth: 0.02
+    - _ToonBorder: 0.45
     m_Colors:
-      data:
-        first:
-          name: _Color
-        second: {r: 1, g: 1, b: 1, a: 1}
-      data:
-        first:
-          name: _ShadowColor
-        second: {r: .800000012, g: .800000012, b: 1, a: 1}
+    - _BlightColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DarkColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/hair.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/hair.mat
@@ -2,78 +2,53 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 3
+  serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: hair
   m_Shader: {fileID: 4800000, guid: 235ca6f7bbc0ead4990f386a7ec24292, type: 3}
-  m_ShaderKeywords: []
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-      data:
-        first:
-          name: _MainTex
-        second:
-          m_Texture: {fileID: 2800000, guid: cbb65ec17f92eb44fb0dde6381b6a415, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _FalloffSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: cc8f70f2ec571e9478efa98c041cde7b, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _RimLightSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _SpecularReflectionSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: c4271b2b1e8bfa949aa9230abaa7709e, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _EnvMapSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: 763c5d30206d1d54a9b49b3309e37fe1, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _NormalMapSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: 9eea3b9b4b755f64da2c821145616f44, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
+    - _EnvMapSampler:
+        m_Texture: {fileID: 2800000, guid: 763c5d30206d1d54a9b49b3309e37fe1, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FalloffSampler:
+        m_Texture: {fileID: 2800000, guid: cc8f70f2ec571e9478efa98c041cde7b, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: cbb65ec17f92eb44fb0dde6381b6a415, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapSampler:
+        m_Texture: {fileID: 2800000, guid: 9eea3b9b4b755f64da2c821145616f44, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _RimLightSampler:
+        m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularReflectionSampler:
+        m_Texture: {fileID: 2800000, guid: c4271b2b1e8bfa949aa9230abaa7709e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
-      data:
-        first:
-          name: _FalloffPower
-        second: .5
-      data:
-        first:
-          name: _EdgeThickness
-        second: .5
-      data:
-        first:
-          name: _SpecularPower
-        second: 20
+    - _EdgeThickness: 0.5
+    - _FalloffPower: 0.5
+    - _OutlineWidth: 0.01
+    - _SpecularPower: 20
     m_Colors:
-      data:
-        first:
-          name: _Color
-        second: {r: 1, g: 1, b: 1, a: 1}
-      data:
-        first:
-          name: _ShadowColor
-        second: {r: .800000012, g: .800000012, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/hair.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/hair.mat
@@ -46,9 +46,11 @@ Material:
     m_Floats:
     - _EdgeThickness: 0.5
     - _FalloffPower: 0.5
-    - _OutlineWidth: 0.01
+    - _OutlineWidth: 0.02
     - _SpecularPower: 20
     m_Colors:
+    - _BlightColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DarkColor: {r: 0.5943396, g: 0.5943396, b: 0.5943396, a: 1}
     - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
     - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/Materials/skin1.mat
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/Materials/skin1.mat
@@ -2,53 +2,43 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 3
+  serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: skin1
   m_Shader: {fileID: 4800000, guid: b35a2abbdd5b15d4ca40103088758eac, type: 3}
-  m_ShaderKeywords: []
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-      data:
-        first:
-          name: _MainTex
-        second:
-          m_Texture: {fileID: 2800000, guid: cc51a9a8397e3c5498dda60419ad3ec9, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _FalloffSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a1d5b2277eb3f6245900378e6fa97575, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-      data:
-        first:
-          name: _RimLightSampler
-        second:
-          m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
+    - _FalloffSampler:
+        m_Texture: {fileID: 2800000, guid: a1d5b2277eb3f6245900378e6fa97575, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: cc51a9a8397e3c5498dda60419ad3ec9, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _RimLightSampler:
+        m_Texture: {fileID: 2800000, guid: a18067604964b5a4d8fd5552ed0d789e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
-      data:
-        first:
-          name: _FalloffPower
-        second: 1
-      data:
-        first:
-          name: _EdgeThickness
-        second: .5
+    - _EdgeThickness: 0.5
+    - _FalloffPower: 1
+    - _OutlineWidth: 0.02
+    - _ToonBorder: 0.73
     m_Colors:
-      data:
-        first:
-          name: _Color
-        second: {r: 1, g: 1, b: 1, a: 1}
-      data:
-        first:
-          name: _ShadowColor
-        second: {r: .800000012, g: .800000012, b: 1, a: 1}
+    - _BlightColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DarkColor: {r: 0.6037736, g: 0.6037736, b: 0.6037736, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ShadowColor: {r: 0.8, g: 0.8, b: 1, a: 1}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/CharaMain.cg
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/CharaMain.cg
@@ -27,6 +27,11 @@ sampler2D _NormalMapSampler;
 
 #ifdef ENABLE_CAST_SHADOWS
 
+#ifdef ENABLE_TOON
+float4 _BlightColor;
+float4 _DarkColor;
+#endif
+
 // Structure from vertex shader to fragment shader
 struct v2f
 {
@@ -161,6 +166,13 @@ float4 frag( v2f i ) : COLOR
 	combinedColor = lerp( combinedColor, reflectColor, reflectionMaskColor.a );
 	combinedColor *= _Color.rgb * _LightColor0.rgb;
 	float opacity = diffSamplerColor.a * _Color.a * _LightColor0.a;
+
+#ifdef ENABLE_TOON
+	float3 lightDir = normalize(_WorldSpaceLightPos0);
+	float NdotL = saturate(dot(i.normal, lightDir));
+	float4 toonColor = lerp(_BlightColor, _DarkColor, step(NdotL, 0.5));
+	combinedColor *= toonColor;
+#endif
 
 #ifdef ENABLE_CAST_SHADOWS
 	// Cast shadows

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/CharaSkin.cg
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/CharaSkin.cg
@@ -18,6 +18,12 @@ sampler2D _MainTex;
 sampler2D _FalloffSampler;
 sampler2D _RimLightSampler;
 
+#ifdef ENABLE_TOON
+float4 _BlightColor;
+float4 _DarkColor;
+float _ToonBorder;
+#endif
+
 // Constants
 #define FALLOFF_POWER 1.0
 
@@ -85,6 +91,15 @@ float4 frag( v2f i ) : COLOR
 	float_t falloffU = clamp( 1 - abs( normalDotEye ), 0.02, 0.98 );
 	float4_t falloffSamplerColor = FALLOFF_POWER * tex2D( _FalloffSampler, float2( falloffU, 0.25f ) );
 	float3_t combinedColor = lerp( diffSamplerColor.rgb, falloffSamplerColor.rgb * diffSamplerColor.rgb, falloffSamplerColor.a );
+
+#ifdef ENABLE_TOON
+	float3 lightDir = normalize(_WorldSpaceLightPos0);
+	float NdotL = saturate(dot(i.normal, lightDir));
+
+	float4 toonColor = lerp(_BlightColor, _DarkColor, step(NdotL, _ToonBorder));
+
+	combinedColor *= toonColor;
+#endif
 
 	// Rimlight
 	float_t rimlightDot = saturate( 0.5 * ( dot( i.normal, i.lightDir ) + 1.0 ) );

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_fuku_ds.shader
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_fuku_ds.shader
@@ -15,6 +15,8 @@ Shader "UnityChan/Clothing - Double-sided"
 		_NormalMapSampler ("Normal Map", 2D) = "" {} 
 		_OutlineWidth ("Outline Width", float) = 0.05
 		_OutlineColor ("Outline Color", Color) = (0, 0, 0, 1)
+		_BlightColor ("Blight Color", Color) = (1, 1, 1, 1)
+		_DarkColor ("Dark Color", Color) = (0, 0, 0, 1)
 	}
 
 	SubShader
@@ -78,6 +80,7 @@ CGPROGRAM
 #include "UnityCG.cginc"
 #include "AutoLight.cginc"
 #define ENABLE_NORMAL_MAP
+#define ENABLE_TOON
 #include "CharaMain.cg"
 ENDCG
 		}

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_fuku_ds.shader
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_fuku_ds.shader
@@ -13,6 +13,8 @@ Shader "UnityChan/Clothing - Double-sided"
 		_SpecularReflectionSampler ("Specular / Reflection Mask", 2D) = "white" {}
 		_EnvMapSampler ("Environment Map", 2D) = "" {} 
 		_NormalMapSampler ("Normal Map", 2D) = "" {} 
+		_OutlineWidth ("Outline Width", float) = 0.05
+		_OutlineColor ("Outline Color", Color) = (0, 0, 0, 1)
 	}
 
 	SubShader
@@ -22,7 +24,47 @@ Shader "UnityChan/Clothing - Double-sided"
 			"RenderType"="Opaque"
 			"Queue"="Geometry"
 			"LightMode"="ForwardBase"
-		}		
+		}
+
+		Pass
+		{
+			Cull Front
+			
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+
+			float _OutlineWidth;
+			float4 _OutlineColor;
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float4 normal : NORMAL;
+			};
+
+			struct v2f
+			{
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert(appdata v)
+			{
+				v2f o;
+				float4 normal = mul(UNITY_MATRIX_IT_MV, v.normal);	// UNITY_MATRIX_IT_MVはMVの逆行列の転置行列
+				float2 offset = TransformViewToProjection(normal.xy);	// zを求めても意味がないので求めない
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.vertex.xy += offset.xy * o.vertex.z * _OutlineWidth;	// 遠くても小さくても同じ大きさのアウトラインを作るため
+				return o;
+			}
+
+			fixed4 frag(v2f i) : SV_Target
+			{
+				return _OutlineColor;
+			}
+			ENDCG
+		}	
 
 		Pass
 		{

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hada.shader
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hada.shader
@@ -9,6 +9,11 @@ Shader "UnityChan/Skin"
 		_MainTex ("Diffuse", 2D) = "white" {}
 		_FalloffSampler ("Falloff Control", 2D) = "white" {}
 		_RimLightSampler ("RimLight Control", 2D) = "white" {}
+		_OutlineWidth ("Outline Width", float) = 0.05
+		_OutlineColor ("Outline Color", Color) = (0, 0, 0, 1)
+		_BlightColor ("Blight Color", Color) = (1, 1, 1, 1)
+		_DarkColor ("Dark Color", Color) = (0, 0, 0, 1)
+		_ToonBorder ("Toon Border", Range(0, 1)) = 0.5
 	}
 
 	SubShader
@@ -22,6 +27,46 @@ Shader "UnityChan/Skin"
 
 		Pass
 		{
+			Cull Front
+
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+
+			float _OutlineWidth;
+			float4 _OutlineColor;
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float4 normal : NORMAL;
+			};
+
+			struct v2f
+			{
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert(appdata v)
+			{
+				v2f o;
+				float4 normal = mul(UNITY_MATRIX_IT_MV, v.normal);
+				float2 offset = TransformViewToProjection(normal.xy);
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.vertex.xy += offset * o.vertex.z * _OutlineWidth;
+				return o;
+			}
+
+			fixed4 frag(v2f i) : SV_Target
+			{
+				return _OutlineColor;
+			}
+			ENDCG
+		}
+
+		Pass
+		{
 			Cull Back
 			ZTest LEqual
 CGPROGRAM
@@ -29,6 +74,7 @@ CGPROGRAM
 #pragma target 3.0
 #pragma vertex vert
 #pragma fragment frag
+#define ENABLE_TOON
 #include "UnityCG.cginc"
 #include "AutoLight.cginc"
 #include "CharaSkin.cg"

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hair_ds.shader
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hair_ds.shader
@@ -13,6 +13,8 @@ Shader "UnityChan/Hair - Double-sided"
 		_SpecularReflectionSampler ("Specular / Reflection Mask", 2D) = "white" {}
 		_EnvMapSampler ("Environment Map", 2D) = "" {} 
 		_NormalMapSampler ("Normal Map", 2D) = "" {} 
+		_OutlineWidth ("Outline Width", float) = 0.01
+		_OutlineColor ("Outline Color", Color) = (0, 0, 0, 1)
 	}
 
 	SubShader
@@ -22,6 +24,46 @@ Shader "UnityChan/Hair - Double-sided"
 			"RenderType"="Opaque"
 			"Queue"="Geometry"
 			"LightMode"="ForwardBase"
+		}
+
+		Pass
+		{
+			Cull Front
+
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+
+			float _OutlineWidth;
+			float4 _OutlineColor;
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float4 normal : NORMAL;
+			};
+
+			struct v2f
+			{
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert(appdata v)
+			{
+				v2f o;
+				float4 normal = mul(UNITY_MATRIX_IT_MV, v.normal);
+				float2 offset = TransformViewToProjection(normal.xy);
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.vertex.xy += offset * o.vertex.z * _OutlineWidth;
+				return o;
+			}
+
+			fixed4 frag(v2f i) : SV_Target
+			{
+				return _OutlineColor;
+			}
+			ENDCG
 		}		
 
 		Pass

--- a/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hair_ds.shader
+++ b/Assets/unity-chan!/Unity-chan! Model/Art/UnityChanShader/Shader/Unitychan_chara_hair_ds.shader
@@ -15,6 +15,8 @@ Shader "UnityChan/Hair - Double-sided"
 		_NormalMapSampler ("Normal Map", 2D) = "" {} 
 		_OutlineWidth ("Outline Width", float) = 0.01
 		_OutlineColor ("Outline Color", Color) = (0, 0, 0, 1)
+		_BlightColor ("Blight Color", Color) = (1, 1, 1, 1)
+		_DarkColor ("Dark Color", Color) = (0, 0, 0, 1)
 	}
 
 	SubShader
@@ -78,6 +80,7 @@ CGPROGRAM
 #include "UnityCG.cginc"
 #include "AutoLight.cginc"
 #define ENABLE_NORMAL_MAP
+#define ENABLE_TOON
 #include "CharaMain.cg"
 ENDCG
 		}


### PR DESCRIPTION
# 目的

いくつものメッシュからなるモデルでToonシェーダーが実装できるか検証。

# 実装概要

- 古典的な2パスレンダリングの方法
- アウトラインの太さは距離に依存しないように、z値を考慮して計算
- 影の濃淡は2レベル設定できる